### PR TITLE
Fix Model.destroy with where and limit

### DIFF
--- a/lib/dialects/oracle/query-generator.js
+++ b/lib/dialects/oracle/query-generator.js
@@ -786,23 +786,26 @@ const QueryGenerator = {
     let limit = '';
     const query = 'DELETE FROM <%= table %><%= where %><%= limit %>;';
 
+    const baseReplacements = {
+      table: this.quoteTable(table)
+    };
+
     if (!!options.limit) {
       //Style of drop with limit with Oracle : delete from table where rowid IN (select rowid from table where rownum <= 10)
       //If where have thee drop statement inside where (as unit test delete.test.js), we don't do anything on limit
+      var limitTmpl;
       if (where.length > 0) {
         //Where clause, we add this at the end
-        limit = ' AND rowid IN(SELECT rowid FROM <%= table %> WHERE rownum <=' + options.limit + ')';
+        limitTmpl = ' AND rowid IN(SELECT rowid FROM <%= table %> WHERE rownum <=' + options.limit + ')';
       } else {
         //No where clause, create one
-        limit = ' WHERE rowid IN(SELECT rowid FROM <%= table %> WHERE rownum <=' + options.limit + ')';
+        limitTmpl = ' WHERE rowid IN(SELECT rowid FROM <%= table %> WHERE rownum <=' + options.limit + ')';
       }
+      limit = Utils._.template(limitTmpl)(baseReplacements);
     }
 
-    const replacements = {
-      limit,
-      table: this.quoteTable(table),
-      where,
-    };
+
+    const replacements = Utils._.assign({limit, where}, baseReplacements);
 
     if (replacements.where) {
       replacements.where = ' WHERE ' + replacements.where;

--- a/lib/dialects/oracle/query-generator.js
+++ b/lib/dialects/oracle/query-generator.js
@@ -784,34 +784,26 @@ const QueryGenerator = {
 
     where = this.getWhereConditions(where);
     let limit = '';
-    const query = 'DELETE FROM <%= table %><%= where %><%= limit %>;';
+    const query = 'DELETE FROM <%= table %><%= limit %>;';
 
-    const baseReplacements = {
-      table: this.quoteTable(table)
+    const replacements = {
+      table: this.quoteTable(table),
+      limit: options.limit,
+      where: where
     };
 
+    var queryTmpl;
+    // delete with limit <l> and optional condition <e> on Oracle: DELETE FROM <t> WHERE rowid in (SELECT rowid FROM <t> WHERE <e> AND rownum <= <l>)
+    // Note that the condition <e> has to be in the subquery; otherwise, the subquery would select <l> arbitrary rows.
     if (!!options.limit) {
-      //Style of drop with limit with Oracle : delete from table where rowid IN (select rowid from table where rownum <= 10)
-      //If where have thee drop statement inside where (as unit test delete.test.js), we don't do anything on limit
-      var limitTmpl;
-      if (where.length > 0) {
-        //Where clause, we add this at the end
-        limitTmpl = ' AND rowid IN(SELECT rowid FROM <%= table %> WHERE rownum <=' + options.limit + ')';
-      } else {
-        //No where clause, create one
-        limitTmpl = ' WHERE rowid IN(SELECT rowid FROM <%= table %> WHERE rownum <=' + options.limit + ')';
-      }
-      limit = Utils._.template(limitTmpl)(baseReplacements);
+      const whereTmpl = where ? ' AND <%= where %>' : '';
+      queryTmpl = 'DELETE FROM <%= table %> WHERE rowid IN (SELECT rowid FROM <%= table %> WHERE rownum <= <%= limit %>' + whereTmpl + ')';
+    } else {
+      const whereTmpl = where ? ' WHERE <%= where %>' : '';
+      queryTmpl = 'DELETE FROM <%= table %>' + whereTmpl;
     }
 
-
-    const replacements = Utils._.assign({limit, where}, baseReplacements);
-
-    if (replacements.where) {
-      replacements.where = ' WHERE ' + replacements.where;
-    }
-
-    return _.template(query)(replacements);
+    return _.template(queryTmpl)(replacements);
   },
 
   showIndexesQuery(tableName) {


### PR DESCRIPTION
This PR fixes SQL generation for `Model.destroy` calls with `where` and `limit` parameters. Currently, using `Model.destroy` with `where` and `limit` (e.g. `User.destroy({ where: { rank: { gt: 3 }}, limit: 3 })`) results in an error:

```
Executing (default): DELETE FROM Users WHERE rank > 3 AND rowid IN(SELECT rowid FROM <%= table %> WHERE rownum <=3)
{ SequelizeDatabaseError: ORA-00903: invalid table name
```

There are two problems in `deleteQuery` (`lib/dialects/oracle/query-generator.js`):

* The template in `deleteQuery` is not instantiated correctly (table name in the subquery is not expanded).
* Once the template is fixed, the semantics of `deleteQuery` does not align with the other dialects. Those implement `Model.destroy({ where: <e>, limit: <l> }) for some condition <e> and some limit <l> as 'delete rows matching <e>, but not more than <l>'. For the Oracle dialect, however, the subquery selects <l> arbitrary rows and then deletes those rows among them that happen to fulfill condition <e>. Effectively, this forms the intersection of <l> arbitrary rows and all rows matching <e>. In most cases, this will not delete any rows at all.

This PR changes the query template to generate the following query:

```
delete from <t> where rowid in (select rowid from <t> where <e> and rownum <= <l>)
```

(this is aligned with `lib/dialects/postgres/query-generator.js`).

